### PR TITLE
config: explicitly set chunk_size to default value

### DIFF
--- a/lib/drops_web/live/basic_uploads_live.ex
+++ b/lib/drops_web/live/basic_uploads_live.ex
@@ -6,7 +6,7 @@ defmodule DropsWeb.BasicUploadsLive do
     {:ok,
      socket
      |> assign(:uploaded_files, [])
-     |> allow_upload(:exhibit, accept: ~w(video/* image/*), max_entries: 6, chunk_size: 1_024)}
+     |> allow_upload(:exhibit, accept: ~w(video/* image/*), max_entries: 6, chunk_size: 64_000)}
   end
 
   @impl true


### PR DESCRIPTION
This sets the `chunk_size` to it's default value of 64 000 bytes rather than 1 024. From my experience this is a safer default to make sure that uploads aren't throttled. We could remove `chunk_size` completely but I like documenting in the basic example that it can be changed.